### PR TITLE
Update ecgf.yaml

### DIFF
--- a/envs/ecgf.yaml
+++ b/envs/ecgf.yaml
@@ -1,10 +1,13 @@
 channels:
-        - bioconda
+- defaults
+- conda-forge
+- bioconda
 dependencies:
-        - python=3.7
-        - git
-        - blast
-        - biopython
-        - numpy
-        #- pip:
-        #        - "--editable=git+https://github.com/dorbarker/CGFPrediction.git@improvements"
+- git
+- python=3.7
+- pip
+- numpy
+- biopython
+- blast
+- pip:
+  - "git+https://github.com/dorbarker/CGFPrediction.git@improvements"


### PR DESCRIPTION
This environment file worked when using the `conda` directive in the `ecgf` rule to create the environment while running the rule. `snakemake` v 5.4.0 was run with the `--use-conda` flag. Please feel free to change the indentation to be consistent with your other environment YAML files.